### PR TITLE
Update rpcclient.cpp

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -167,6 +167,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "searchrawtransactions", 1 },
     { "searchrawtransactions", 2 },
     { "searchrawtransactions", 3 },
+    { "scanforalltxns", 0 },
+    { "scanforstealthtxns", 0 },
 };
 
 class CRPCConvertTable


### PR DESCRIPTION
The console command "scanforalltxns" and "scanforstealthtxns" works now with a parameter (see in console "help scanforalltxns").
e.g. "scanforalltxns  225000" scans the blockchain for owned transactions from block height 225000.